### PR TITLE
feat(offline-mode): Add support for offline handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flagsmith"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Gagan Trivedi <gagan.trivedi@flagsmith.com>"]
 edition = "2021"
 license = "BSD-3-Clause"

--- a/src/flagsmith/analytics.rs
+++ b/src/flagsmith/analytics.rs
@@ -1,10 +1,10 @@
+use flume;
 use log::{debug, warn};
 use reqwest::header::HeaderMap;
 use serde_json;
-use flume;
 use std::{collections::HashMap, thread};
 
-use std::sync::{Arc,  RwLock};
+use std::sync::{Arc, RwLock};
 static ANALYTICS_TIMER_IN_MILLI: u64 = 10 * 1000;
 
 #[derive(Clone, Debug)]

--- a/src/flagsmith/offline_handler.rs
+++ b/src/flagsmith/offline_handler.rs
@@ -1,0 +1,44 @@
+use flagsmith_flag_engine::environments::Environment;
+use std::fs;
+
+pub trait OfflineHandler {
+    fn get_environment(&self) -> Environment;
+}
+
+pub struct LocalFileHandler {
+    environment: Environment,
+}
+
+impl LocalFileHandler {
+    pub fn new(environment_document_path: &str) -> Result<Self, std::io::Error> {
+        // Read the environment document from the specified path
+        let environment_document = fs::read(environment_document_path)?;
+
+        // Deserialize the JSON into EnvironmentModel
+        let environment: Environment = serde_json::from_slice(&environment_document)?;
+
+        // Create and initialize the LocalFileHandler
+        let handler = LocalFileHandler { environment };
+
+        Ok(handler)
+    }
+}
+
+impl OfflineHandler for LocalFileHandler {
+    fn get_environment(&self) -> Environment {
+        self.environment.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_local_file_handler() {
+        let handler = LocalFileHandler::new("tests/fixtures/environment.json").unwrap();
+
+        let environment = handler.get_environment();
+        assert_eq!(environment.api_key, "B62qaMZNwfiqT76p38ggrQ");
+    }
+}

--- a/tests/fixtures/environment.json
+++ b/tests/fixtures/environment.json
@@ -1,0 +1,58 @@
+{
+            "api_key": "B62qaMZNwfiqT76p38ggrQ",
+            "project": {
+                "name": "Test project",
+                "organisation": {
+                    "feature_analytics": false,
+                    "name": "Test Org",
+                    "id": 1,
+                    "persist_trait_data": true,
+                    "stop_serving_flags": false
+                },
+                "id": 1,
+                "hide_disabled_flags": false,
+                "segments": [
+                    {
+                        "id": 1,
+                        "name": "Test Segment",
+                        "feature_states":[],
+                        "rules": [
+                            {
+                                "type": "ALL",
+                                "conditions": [],
+                                "rules": [
+                                    {
+                                        "type": "ALL",
+                                        "rules": [],
+                                        "conditions": [
+                                            {
+                                                "operator": "EQUAL",
+                                                "property_": "foo",
+                                                "value": "bar"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "segment_overrides": [],
+            "id": 1,
+            "feature_states": [
+                {
+                    "multivariate_feature_state_values": [],
+                    "feature_state_value": "some_value",
+                    "id": 1,
+                    "featurestate_uuid": "40eb539d-3713-4720-bbd4-829dbef10d51",
+                    "feature": {
+                        "name": "feature_1",
+                        "type": "STANDARD",
+                        "id": 1
+                    },
+                    "segment_id": null,
+                    "enabled": true
+                }
+            ]
+    }


### PR DESCRIPTION
Implement offline handler(/offline mode) based on the spec defined [here](https://github.com/Flagsmith/flagsmith/issues/2024)