### PR TITLE
docs: removing hero image from SDK readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 [![Docs](https://docs.rs/bullettrain/badge.svg)](https://docs.rs/flagsmith/)
 [![Rust](https://github.com/Flagsmith/flagsmith-rust-client/workflows/Rust/badge.svg)](https://github.com/Flagsmith/flagsmith-rust-client/actions?query=workflow%3ARust)
 
-![Flagsmith Screenshot](https://github.com/Flagsmith/flagsmith/raw/main/static-files/hero.png)
-
 # Flagsmith Rust SDK
 
 > Flagsmith allows you to manage feature flags and remote config across multiple projects, environments and organisations.


### PR DESCRIPTION
To remove the risk of these breaking when we make changes in flagsmith/flagsmith we're removing these image references from the readme.md files of the SDK repos.